### PR TITLE
Revised per @Umofomia feedback

### DIFF
--- a/git-spec
+++ b/git-spec
@@ -8,7 +8,13 @@ require 'open3'
 # path conventions)
 class SpecDiff
   def call
-    unsplit_files = `git whatchanged --name-only --pretty="" origin..HEAD`
+    ancestor = `git merge-base HEAD origin`
+
+    # This will return changes that haven't been comitted yet.
+    unsplit_files = `git diff --name-only #{ancestor}`
+
+    # This will return only committed changes.
+    # unsplit_files = `git diff --name-only $(ancestor)..HEAD`
 
     files = unsplit_files.split("\n")
 

--- a/git-spec
+++ b/git-spec
@@ -70,17 +70,16 @@ class SpecDiff
 
   # Streams the output a character at a time, since the Rspec output is one
   # dot per spec on a single line.
-  # based largely off https://nickcharlton.net/posts/ruby-subprocesses-with-stdout-stderr-streams.html
+  # based off https://nickcharlton.net/posts/ruby-subprocesses-with-stdout-stderr-streams.html
   # @return [Fixnum] the status code from the spec command
   def run_command(cmd)
     exit_status = nil
 
     Open3.popen3(cmd) do |stdin, stdout, stderr, thread|
-      # read each stream from a new thread
-      { :out => stdout, :err => stderr }.each do |key, stream|
+      { stdout => $stdout, stderr => $stderr }.each do |source, destination|
         Thread.new do
-          until (character = stream.getc).nil? do
-            putc character
+          until (character = source.getc).nil? do
+            destination.putc character
           end
         end
       end

--- a/git-spec
+++ b/git-spec
@@ -7,6 +7,7 @@ require 'open3'
 # it will try and see if there is a spec for that file (using Rails
 # path conventions)
 class SpecDiff
+  # @return [Fixnum] the spec status code
   def call
     ancestor = `git merge-base HEAD origin`
 
@@ -32,7 +33,9 @@ class SpecDiff
 
     puts 'Running'
     puts command
-    run_command command
+    exit_status = run_command(command)
+
+    exit_status
   end
 
   private
@@ -68,7 +71,10 @@ class SpecDiff
   # Streams the output a character at a time, since the Rspec output is one
   # dot per spec on a single line.
   # based largely off https://nickcharlton.net/posts/ruby-subprocesses-with-stdout-stderr-streams.html
+  # @return [Fixnum] the status code from the spec command
   def run_command(cmd)
+    exit_status = nil
+
     Open3.popen3(cmd) do |stdin, stdout, stderr, thread|
       # read each stream from a new thread
       { :out => stdout, :err => stderr }.each do |key, stream|
@@ -80,9 +86,12 @@ class SpecDiff
       end
 
       thread.join # don't exit until the external process is done
+      # thread.value returns a Process::Status object
+      exit_status = thread.value.exitstatus
     end
-  end
 
+    exit_status
+  end
 end
 
-SpecDiff.new.call
+exit SpecDiff.new.call


### PR DESCRIPTION
The gotcha is that the previous version used "origin" which is a shortcut
for the local copy of the default branch. So, it would be a shortcut
to "origin/master". If new commits come in and you run a "fetch", it means
that the default branch is now different. I missed this b/c in my testing,
I hadn't done a fetch, so it seemed correct.